### PR TITLE
Add missing assignment for identity_provider_id_regex instance variable

### DIFF
--- a/lib/omniauth/saml/multi_provider/handler.rb
+++ b/lib/omniauth/saml/multi_provider/handler.rb
@@ -12,12 +12,12 @@ module OmniAuth
           raise 'Missing provider options generator block' unless block_given?
 
           @path_prefix = path_prefix
-          @identity_provider_id_regex
+          @identity_provider_id_regex = identity_provider_id_regex
           @identity_provider_options_generator = identity_provider_options_generator
 
           # Eagerly compute these since lazy evaluation will not be threadsafe
-          @provider_path_prefix = "#{path_prefix}/saml"
-          @saml_path_regex = /^#{@provider_path_prefix}\/(?<identity_provider_id>#{identity_provider_id_regex})/
+          @provider_path_prefix = "#{@path_prefix}/saml"
+          @saml_path_regex = /^#{@provider_path_prefix}\/(?<identity_provider_id>#{@identity_provider_id_regex})/
           @request_path_regex = /#{saml_path_regex}\/?$/
           @callback_path_regex = /#{saml_path_regex}\/callback\/?$/
         end

--- a/spec/omniauth/saml/multi_provider/handler_spec.rb
+++ b/spec/omniauth/saml/multi_provider/handler_spec.rb
@@ -39,7 +39,7 @@ describe OmniAuth::SAML::MultiProvider::Handler do
       end
 
       it "returns false for request paths that don't match the identity provider id regex" do
-        rack_env = create_rack_env(path: "#{path_prefix}/foo123")
+        rack_env = create_rack_env(path: "#{path_prefix}/saml/foo123")
         expect(request_path_proc.call(rack_env)).to eq false
       end
 


### PR DESCRIPTION
Despite the missing assigment, this worked because the keyword arguments
were referenced directly.

Fixes #1
